### PR TITLE
gofsck: Implement better symbol grouping with an allow list

### DIFF
--- a/gofsck/.golangci.yml
+++ b/gofsck/.golangci.yml
@@ -1,5 +1,11 @@
 version: "2"
 
+issues:
+  max-issues-per-linter: 0
+
+run:
+  issues-exit-code: 0
+
 linters:
   settings:
     custom:

--- a/gofsck/README.md
+++ b/gofsck/README.md
@@ -46,19 +46,25 @@ large package scopes which are typical for the "big ball of mud"
 architecture style, renaming files to correspond to symbol name is
 typical practice in some other languages.
 
-## File naming
+## Scope
 
-- A symbol of `ServiceDisovery` is expected in `service_discovery.go`.
-- A symbol of `ServiceDiscovery.Get` is expected in `service_discovery_get.go` or `service_discovery.go`.
-- The tests for `ServiceDiscovery.Get` should match the name in an adjacent `_test.go` file.
+The tool checks that typed structs and functions with an exported
+receiver are grouped into the correct expected files:
 
-Depending on the declaration kind, additional locations are envisioned:
+- A symbol of `ServiceDiscovery` is expected in `service_discovery.go` or `service*.go`.
+- A symbol of `ServiceDiscovery.Get` is expected in `service_discovery_get.go` or `service_discovery.go`, or `service*.go`.
 
-- constants are global, put them in `consts.go`,
-- vars are global, put them in `vars.go`,
-- data model goes into `types.go` or own package
+Beyond this assertion, some typical filenames are allowed, based on
+symbol type grouping that's a common practice in smaller projects:
 
-## Test naming
+- `model*.go` - holds data model `type` definitions
+- `types*.go` - holds `type` definitions
+
+Ultimately, a lot of packages are small and may contain a single file.
+For a package named `sqlite3`, the exception is to group all symbols in
+`sqlite3/sqlite3.go`.
+
+## Future
 
 The structure is checked with unit tests in mind. Black box unit tests are
 a good way to have the full symbol reference searchable in the source code.
@@ -69,6 +75,10 @@ a good way to have the full symbol reference searchable in the source code.
 
 Using `t.Run` within tests is expected for more fine grained tests.
 
+This structural check isn't currently implemented. The application
+couplings with tests vary greatly, and would better live in a separate
+linter for the purpose.
+
 ## Typical violations
 
 Here are a few typical violations of package structure:
@@ -77,8 +87,9 @@ Here are a few typical violations of package structure:
 - arbitrarily named tests causing duplication
 - multiple type definitions in a single file
 - a single definition over multiple files
-- shared utilities in the same package
-- integration tests not in dedicated packages
+- shared utilities in the same package (globals)
+- integration tests not in dedicated packages (white box tests)
 
 The tooling encourages single responsibility and the testing benefits
-that come with such practices.
+that come with such practices. It concentrates on sorting exported
+package typed structs and the functions bound to them.

--- a/gofsck/pkg/gofsck/analyzer.go
+++ b/gofsck/pkg/gofsck/analyzer.go
@@ -27,7 +27,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	// Traverse the abstract syntax tree (AST) for each file in the package
 	for _, file := range pass.Files {
-		fileName := strings.TrimSpace(pass.Fset.Position(file.Pos()).Filename)
+		fileName := pass.Fset.Position(file.Pos()).Filename
 
 		// No rules enforced in tests
 		if strings.HasSuffix(fileName, "_test.go") {

--- a/gofsck/pkg/gofsck/analyzer.go
+++ b/gofsck/pkg/gofsck/analyzer.go
@@ -74,10 +74,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func handleFuncDecl(pass *analysis.Pass, decl *ast.FuncDecl, fileName string, symbols *[]AnalyzerSymbol) {
 	// Get the receiver's name (if any) and the function name
 	receiver := getReceiverName(decl)
-
 	if receiver == "" {
 		return
 	}
+
 	if !ast.IsExported(receiver) {
 		return
 	}

--- a/gofsck/pkg/gofsck/analyzer_symbol.go
+++ b/gofsck/pkg/gofsck/analyzer_symbol.go
@@ -8,6 +8,7 @@ type AnalyzerSymbol struct {
 	Symbol   string
 	Receiver string
 	Type     string
+	Package  string
 	Default  string
 
 	Pos token.Pos

--- a/gofsck/pkg/gofsck/analyzer_symbol.go
+++ b/gofsck/pkg/gofsck/analyzer_symbol.go
@@ -10,8 +10,7 @@ type AnalyzerSymbol struct {
 	Type     string
 	Default  string
 
-	IsTest bool // Track if it's a test symbol
-	Pos    token.Pos
+	Pos token.Pos
 }
 
 func (s *AnalyzerSymbol) String() string {

--- a/gofsck/pkg/gofsck/analyzer_test.go
+++ b/gofsck/pkg/gofsck/analyzer_test.go
@@ -24,6 +24,10 @@ func TestAnalyzer(t *testing.T) {
 		"wrong_file.go": {
 			`exported type "MyService" does not match filename or fallback to testdata*.go`,
 		},
+		"client.go": {
+			"exported type \"HTTPClient\" does not match filename or fallback to testdata*.go",
+			"exported func \"HTTPClient.Request\" does not match filename or fallback to testdata*.go",
+		},
 	}
 
 	// Run the analyzer against the test data

--- a/gofsck/pkg/gofsck/analyzer_test.go
+++ b/gofsck/pkg/gofsck/analyzer_test.go
@@ -22,11 +22,11 @@ func TestAnalyzer(t *testing.T) {
 	// Expected diagnostics based on the testdata (formatted as "file.go: exported type %q does not match filename")
 	expected := map[string][]string{
 		"wrong_file.go": {
-			`exported type "MyService" does not match filename or fallback to testdata*.go`,
+			`exported type "MyService" does not match filename or fallback to model*.go`,
 		},
 		"client.go": {
-			"exported type \"HTTPClient\" does not match filename or fallback to testdata*.go",
-			"exported func \"HTTPClient.Request\" does not match filename or fallback to testdata*.go",
+			"exported type \"HTTPClient\" does not match filename or fallback to model*.go",
+			"exported func \"HTTPClient.Request\" does not match filename or fallback to model*.go",
 		},
 	}
 

--- a/gofsck/pkg/gofsck/analyzer_test.go
+++ b/gofsck/pkg/gofsck/analyzer_test.go
@@ -22,7 +22,7 @@ func TestAnalyzer(t *testing.T) {
 	// Expected diagnostics based on the testdata (formatted as "file.go: exported type %q does not match filename")
 	expected := map[string][]string{
 		"wrong_file.go": {
-			`exported type "MyService" does not match filename or fallback to types.go`,
+			`exported type "MyService" does not match filename or fallback to testdata*.go`,
 		},
 	}
 

--- a/gofsck/pkg/gofsck/match.go
+++ b/gofsck/pkg/gofsck/match.go
@@ -59,8 +59,6 @@ func matchFilenames(name, receiver, defaultFile string) []string {
 	for _, name := range partials {
 		result = append(result, matchFilename(name+suffix))
 
-		suffix = "*"
-
 		singularName = getSingular(name)
 		if singularName != name {
 			result = append(result, matchFilename(singularName+suffix))
@@ -70,9 +68,14 @@ func matchFilenames(name, receiver, defaultFile string) []string {
 		if baseName != name {
 			result = append(result, matchFilename(baseName+suffix))
 		}
+
+		if strings.Count(name, "_") == 1 {
+			suffix = "*"
+		}
 	}
 
 	result = append(result, defaultFile)
+
 	return append(result, allowlist...)
 }
 

--- a/gofsck/pkg/gofsck/match.go
+++ b/gofsck/pkg/gofsck/match.go
@@ -8,12 +8,11 @@ import (
 
 // allowlist is a list of files to allow.
 var allowlist = []string{
-	"types.go",
-	"interfaces.go",
-	"consts.go",
-	"const.go",
-	"funcs.go",
 	"model*.go",
+	"types*.go",
+	"interface*.go",
+	"const*.go",
+	"func*.go",
 }
 
 // match returns true if the symbol matches any expected filename patterns.

--- a/gofsck/pkg/gofsck/match.go
+++ b/gofsck/pkg/gofsck/match.go
@@ -10,9 +10,6 @@ import (
 var allowlist = []string{
 	"model*.go",
 	"types*.go",
-	"interface*.go",
-	"const*.go",
-	"func*.go",
 }
 
 // match returns true if the symbol matches any expected filename patterns.
@@ -36,8 +33,13 @@ func matchFilenames(name, receiver, defaultFile string) []string {
 
 	// Constructors should start with New, followed with the type name.
 	// We trim it away so we can group `NewServer` into server.go.
-	if len(name) > 3 && strings.EqualFold(name[:3], "New") {
+	if strings.HasPrefix(name, "New") {
 		name = name[3:]
+	}
+
+	// Types with Err in the name can be grouped to errors.go.
+	if strings.Contains(receiver, "Err") {
+		result = append(result, "errors.go")
 	}
 
 	// make function name exported for naming checks

--- a/gofsck/pkg/gofsck/match.go
+++ b/gofsck/pkg/gofsck/match.go
@@ -32,7 +32,7 @@ func match(symbol AnalyzerSymbol, baseName string) bool {
 
 // matchFilenames generates possible filename stems that could contain the given symbol.
 func matchFilenames(name, receiver, defaultFile string) []string {
-	partials := []string{}
+	var result, partials []string
 
 	// Constructors should start with New, followed with the type name.
 	// We trim it away so we can group `NewServer` into server.go.
@@ -55,21 +55,20 @@ func matchFilenames(name, receiver, defaultFile string) []string {
 	}
 	partials = append(partials, snakeName)
 
-	result := []string{}
-	suffix := ""
+	var baseName, singularName, suffix string
 	for _, name := range partials {
 		result = append(result, matchFilename(name+suffix))
 
 		suffix = "*"
 
-		// Assets{} can be in asset.go.
-		if strings.HasSuffix(name, "s") {
-			result = append(result, matchFilename(name[:len(name)-1]+suffix))
+		singularName = getSingular(name)
+		if singularName != name {
+			result = append(result, matchFilename(singularName+suffix))
 		}
 
-		// Checker{} can be in checker, checks, check.go.
-		if strings.HasSuffix(name, "er") {
-			result = append(result, matchFilename(name[:len(name)-2]+suffix))
+		baseName = getBaseNoun(name)
+		if baseName != name {
+			result = append(result, matchFilename(baseName+suffix))
 		}
 	}
 

--- a/gofsck/pkg/gofsck/match_test.go
+++ b/gofsck/pkg/gofsck/match_test.go
@@ -57,6 +57,19 @@ func Test_matchFilenames(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("Acronym", func(t *testing.T) {
+		got := matchFilenames("Request", "HTTPClient", "default.go")
+		want := []string{
+			"http_client_request.go",
+			"http_client*.go",
+			"http*.go",
+			"default.go",
+		}
+		want = append(want, allowlist...)
+
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("Global bound", func(t *testing.T) {
 		got := matchFilenames("LimiterFunc", "", "default.go")
 		want := []string{

--- a/gofsck/pkg/gofsck/match_test.go
+++ b/gofsck/pkg/gofsck/match_test.go
@@ -11,7 +11,7 @@ func Test_matchFilenames(t *testing.T) {
 		got := matchFilenames("Get", "ServiceDiscovery", "default.go")
 		want := []string{
 			"service_discovery_get.go",
-			"service_discovery*.go",
+			"service_discovery.go",
 			"service*.go",
 			"default.go",
 		}
@@ -61,7 +61,7 @@ func Test_matchFilenames(t *testing.T) {
 		got := matchFilenames("Request", "HTTPClient", "default.go")
 		want := []string{
 			"http_client_request.go",
-			"http_client*.go",
+			"http_client.go",
 			"http*.go",
 			"default.go",
 		}
@@ -87,7 +87,7 @@ func Test_matchFilenames(t *testing.T) {
 		got := matchFilenames("NewSchedulerContextTimeout", "", "default.go")
 		want := []string{
 			"scheduler_context_timeout.go",
-			"scheduler_context*.go",
+			"scheduler_context.go",
 			"scheduler*.go",
 			"schedul*.go",
 			"default.go",

--- a/gofsck/pkg/gofsck/match_test.go
+++ b/gofsck/pkg/gofsck/match_test.go
@@ -20,6 +20,22 @@ func Test_matchFilenames(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("Errors", func(t *testing.T) {
+		got := matchFilenames("String", "ServiceDiscoveryConnectionError", "default.go")
+		want := []string{
+			"errors.go",
+			"service_discovery_connection_error_string.go",
+			"service_discovery_connection_error.go",
+			"service_discovery_connection.go",
+			"service_discovery.go",
+			"service*.go",
+			"default.go",
+		}
+		want = append(want, allowlist...)
+
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("Global", func(t *testing.T) {
 		got := matchFilenames("Get", "", "default.go")
 		want := []string{

--- a/gofsck/pkg/gofsck/match_test.go
+++ b/gofsck/pkg/gofsck/match_test.go
@@ -12,9 +12,10 @@ func Test_matchFilenames(t *testing.T) {
 		want := []string{
 			"service_discovery_get.go",
 			"service_discovery*.go",
-			"get.go",
+			"service*.go",
 			"default.go",
 		}
+		want = append(want, allowlist...)
 
 		assert.Equal(t, want, got)
 	})
@@ -25,6 +26,33 @@ func Test_matchFilenames(t *testing.T) {
 			"get.go",
 			"default.go",
 		}
+		want = append(want, allowlist...)
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("Plurality", func(t *testing.T) {
+		got := matchFilenames("Get", "Assets", "default.go")
+		want := []string{
+			"assets_get.go",
+			"assets*.go",
+			"asset*.go",
+			"default.go",
+		}
+		want = append(want, allowlist...)
+
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("Doer", func(t *testing.T) {
+		got := matchFilenames("Do", "Checker", "default.go")
+		want := []string{
+			"checker_do.go",
+			"checker*.go",
+			"check*.go",
+			"default.go",
+		}
+		want = append(want, allowlist...)
 
 		assert.Equal(t, want, got)
 	})
@@ -34,19 +62,24 @@ func Test_matchFilenames(t *testing.T) {
 		want := []string{
 			"limiter_func.go",
 			"limiter*.go",
+			"limit*.go",
 			"default.go",
 		}
+		want = append(want, allowlist...)
 
 		assert.Equal(t, want, got)
 	})
 
 	t.Run("New", func(t *testing.T) {
-		got := matchFilenames("NewScheduler", "", "default.go")
+		got := matchFilenames("NewSchedulerContextTimeout", "", "default.go")
 		want := []string{
-			"scheduler.go",
-			"new*.go",
+			"scheduler_context_timeout.go",
+			"scheduler_context*.go",
+			"scheduler*.go",
+			"schedul*.go",
 			"default.go",
 		}
+		want = append(want, allowlist...)
 
 		assert.Equal(t, want, got)
 	})

--- a/gofsck/pkg/gofsck/match_test.go
+++ b/gofsck/pkg/gofsck/match_test.go
@@ -21,14 +21,13 @@ func Test_matchFilenames(t *testing.T) {
 	})
 
 	t.Run("Errors", func(t *testing.T) {
-		got := matchFilenames("String", "ServiceDiscoveryConnectionError", "default.go")
+		got := matchFilenames("", "ServiceDiscoveryConnectionError", "default.go")
 		want := []string{
-			"errors.go",
-			"service_discovery_connection_error_string.go",
 			"service_discovery_connection_error.go",
 			"service_discovery_connection.go",
 			"service_discovery.go",
 			"service*.go",
+			"errors.go",
 			"default.go",
 		}
 		want = append(want, allowlist...)

--- a/gofsck/pkg/gofsck/naming.go
+++ b/gofsck/pkg/gofsck/naming.go
@@ -1,9 +1,70 @@
 package gofsck
 
 import (
+	"strings"
+
 	strcase "github.com/stoewer/go-strcase"
 )
 
 func toSnake(input string) string {
 	return strcase.SnakeCase(input)
+}
+
+// getSingular returns the singular form of a word
+// This is a simple implementation that handles common cases
+func getSingular(word string) string {
+	lower := strings.ToLower(word)
+
+	// Common irregular plurals
+	irregulars := map[string]string{
+		"children": "child",
+		"geese":    "goose",
+		"men":      "man",
+		"women":    "woman",
+		"teeth":    "tooth",
+		"feet":     "foot",
+		"mice":     "mouse",
+		"people":   "person",
+	}
+
+	if singular, ok := irregulars[lower]; ok {
+		// Preserve original case for first letter
+		if word[0] >= 'A' && word[0] <= 'Z' {
+			return strings.Title(singular)
+		}
+		return singular
+	}
+
+	// Regular plural patterns
+	if strings.HasSuffix(lower, "ies") && len(word) > 3 {
+		// cities -> city, companies -> company
+		return word[:len(word)-3] + "y"
+	} else if strings.HasSuffix(lower, "es") {
+		if strings.HasSuffix(lower, "sses") || strings.HasSuffix(lower, "xes") ||
+			strings.HasSuffix(lower, "ches") || strings.HasSuffix(lower, "shes") {
+			// classes -> class, boxes -> box, churches -> church, brushes -> brush
+			return word[:len(word)-2]
+		}
+		// heroes -> hero (but not always correct)
+		return word[:len(word)-2]
+	} else if strings.HasSuffix(lower, "s") && !strings.HasSuffix(lower, "ss") {
+		// cars -> car, but not class -> clas
+		return word[:len(word)-1]
+	}
+
+	return word
+}
+
+// getBaseNoun extracts the base noun from "doer" patterns
+// For example: Fetcher -> fetch, Checker -> check
+func getBaseNoun(word string) string {
+	if strings.HasSuffix(word, "er") && len(word) > 2 {
+		base := word[:len(word)-2]
+		// Handle doubling of consonants (e.g., runner -> run)
+		if len(base) > 1 && base[len(base)-1] == base[len(base)-2] {
+			base = base[:len(base)-1]
+		}
+		return base
+	}
+	return word
 }

--- a/gofsck/pkg/gofsck/testdata/asset.go
+++ b/gofsck/pkg/gofsck/testdata/asset.go
@@ -1,0 +1,9 @@
+package model
+
+type Assets struct {
+	data map[string]string
+}
+
+func (a *Assets) Get(key string) string {
+	return a.data[key]
+}

--- a/gofsck/pkg/gofsck/testdata/check.go
+++ b/gofsck/pkg/gofsck/testdata/check.go
@@ -1,0 +1,10 @@
+package model
+
+type Checker struct {
+	rules []string
+}
+
+func (c *Checker) Check(input string) bool {
+	// Implementation details
+	return true
+}

--- a/gofsck/pkg/gofsck/testdata/client.go
+++ b/gofsck/pkg/gofsck/testdata/client.go
@@ -1,0 +1,10 @@
+package model
+
+// This should be allowed in http_client.go due to the allowlist.
+type HTTPClient struct {
+	baseURL string
+}
+
+func (c *HTTPClient) Request(path string) error {
+	return nil
+}

--- a/gofsck/pkg/gofsck/testdata/errors.go
+++ b/gofsck/pkg/gofsck/testdata/errors.go
@@ -1,0 +1,5 @@
+package model
+
+type NotFoundError struct{}
+
+type InvalidRequestError struct{}

--- a/gofsck/pkg/gofsck/testdata/fetch.go
+++ b/gofsck/pkg/gofsck/testdata/fetch.go
@@ -1,0 +1,10 @@
+package model
+
+type Fetcher struct {
+	baseURL string
+}
+
+func (f *Fetcher) Fetch(id string) (string, error) {
+	// Implementation details
+	return "", nil
+}

--- a/gofsck/pkg/gofsck/testdata/interfaces_test.go
+++ b/gofsck/pkg/gofsck/testdata/interfaces_test.go
@@ -1,0 +1,18 @@
+package model
+
+// This interface should be skipped since it's not a struct
+type Repository interface {
+	Get(id string) (interface{}, error)
+	Save(data interface{}) error
+}
+
+// This struct type should also be skipped since it's in a test file
+type MockRepository struct{}
+
+func (m *MockRepository) Get(id string) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockRepository) Save(data interface{}) error {
+	return nil
+}


### PR DESCRIPTION
Gofsck is meant to organize meaningful components into files based on their naming. Implement the following changes:

- Remove const and var parsing, do not sort those symbols
- Don't check if a type is exported or not, same for functions
- Sort types and functions that have a receiver
- Skip type handling if the type is declared in a go test file
- Define an allow list []string of commonly used filenames to group symbols
- Only consider structs, skip interfaces from checks
- Add new matching logic to consider the singular/noun form: assets -> asset*.go, fetcher -> fetch*.go
- Add tests for "Plurality" ("Assets.Get") and "Doer" ("Checker.Do").
- Fix matching logic to properly consider both the receiver name and the symbol name for sorting.
- Update tests.